### PR TITLE
Add encoding options to decode/encode functions

### DIFF
--- a/src/main/clojure/bencode/core.clj
+++ b/src/main/clojure/bencode/core.clj
@@ -11,18 +11,18 @@
   "Bencodes the given object."
   ([obj]
      (bencode obj nil))
-  ([obj opts]
+  ([obj {:keys [encoding] :or {encoding "UTF-8"} :as opts}]
      (let [^ByteArrayOutputStream out (or (get opts :to (ByteArrayOutputStream.)))]
-       (protocol/bencode! obj out opts)
+       (protocol/bencode! obj out (assoc opts :encoding encoding))
        (when-not (:to opts)
          (let [^bytes arr (.toByteArray out)]
            (if (:raw-str? opts)
              arr
-             (String. arr "UTF-8")))))))
+             (String. arr encoding)))))))
 
 (defn bdecode
   "Bdecodes the given input."
   ([in]
      (protocol/bdecode in nil))
-  ([in opts]
-     (protocol/bdecode in opts)))
+  ([in {:keys [encoding] :or {encoding "UTF-8"} :as opts}]
+     (protocol/bdecode in (assoc opts :encoding encoding))))

--- a/src/main/clojure/bencode/metainfo/reader.clj
+++ b/src/main/clojure/bencode/metainfo/reader.clj
@@ -1,11 +1,9 @@
 (ns bencode.metainfo.reader
   (:use [bencode.core])
   (:require [clojure.java.io :as io])
-  (:import [java.io File]
-           [java.net URLEncoder]
+  (:import [java.net URLEncoder]
            [java.security MessageDigest]
-           [java.util Date]
-           [org.apache.commons.codec.binary Base32]))
+           [java.util Date]))
 
 (defn- hex-from-bytes
   "Converts a byte-array to a hex string."

--- a/src/main/clojure/bencode/metainfo/writer.clj
+++ b/src/main/clojure/bencode/metainfo/writer.clj
@@ -1,11 +1,8 @@
 (ns bencode.metainfo.writer
   (:use [bencode.core]
         [bencode.utils])
-  (:require [clojure.string :as str]
-            [clojure.java.io :as io])
+  (:require [clojure.string :as str])
   (:import [java.io File]
-           [java.nio ByteBuffer]
-           [java.security MessageDigest]
            [java.util.concurrent TimeUnit]))
 
 (defn file-path

--- a/src/main/clojure/bencode/protocol.clj
+++ b/src/main/clojure/bencode/protocol.clj
@@ -22,7 +22,7 @@
        (= ch \l)  :list
        (= ch \d)  :dict
        (digit? b) (do (.reset in) :string)
-       :else      :unknown))))
+       :else      (do (.reset in) :unknown)))))
 
-(defmethod bdecode-type! :unknown [seq opts]
-  (error "Unexpected token"))
+(defmethod bdecode-type! :unknown [in opts]
+  (error (str "Unexpected token: " (String. (.read in)))))


### PR DESCRIPTION
Ran into some issues where the enforced default of UTF-8 hurt. Wrote some small changes so that the user can pick an encoding.

I haven't written a test for this. I can if that's desired.